### PR TITLE
animations: set native driver to true

### DIFF
--- a/app/components/Loading/Circle.js
+++ b/app/components/Loading/Circle.js
@@ -69,6 +69,7 @@ class Circle extends React.Component<Props> {
 		return Animated.timing(originalValue, {
 			toValue: newValue,
 			duration,
+			useNativeDriver: true,
 		});
 	}
 

--- a/app/components/Loading/Diamond.js
+++ b/app/components/Loading/Diamond.js
@@ -74,6 +74,7 @@ class Diamond extends React.Component<Props> {
 		return Animated.timing(originalValue, {
 			toValue: newValue,
 			duration,
+			useNativeDriver: true,
 		});
 	}
 

--- a/app/components/Loading/Quadrilateral.js
+++ b/app/components/Loading/Quadrilateral.js
@@ -71,6 +71,7 @@ class Quadrilateral extends React.Component<Props> {
 		return Animated.timing(originalValue, {
 			toValue: newValue,
 			duration,
+			useNativeDriver: true,
 		});
 	}
 


### PR DESCRIPTION
Set the flag useNativeDriver to true so we can use this features
that runs the animations without affecting the js thread.

doc: https://facebook.github.io/react-native/docs/animations